### PR TITLE
CICD/CI-build-tools.md is added

### DIFF
--- a/CICD/CI-build-tools.md
+++ b/CICD/CI-build-tools.md
@@ -1,0 +1,36 @@
+# 🔧 CI/CD Build Tools by Language (Essentials)
+
+In CI/CD, the build stage depends on the project’s language. Here are the key tools used in the industry:
+
+---
+
+## ☕ Java
+- **Maven** / **Gradle**
+- Builds `.jar` / `.war` files
+- Manages dependencies and runs tests
+
+---
+
+## 🌐 Node.js
+- **npm** / **yarn**
+- Installs packages, runs scripts (build, test, lint)
+- Often used with bundlers like Webpack
+
+---
+
+## 🐍 Python
+- **pip** / **poetry**
+- Installs from `requirements.txt` or `pyproject.toml`
+- Works with testing tools like `pytest`
+
+---
+
+## 🦫 Go
+- **go build**
+- Compiles Go code into static binaries
+- Uses `go mod` for dependency management
+
+---
+
+## 🧠 Summary
+Choose the right build tool based on the language. This step prepares your code for testing and packaging in CI/CD pipelines.


### PR DESCRIPTION
This file explains the common build tools used in Continuous Integration (CI) pipelines based on different programming languages. It is designed to help beginners understand how to choose the right tools for automating builds, tests, and packaging in a CI/CD workflow.